### PR TITLE
2024-03 and 2024-06 release plans

### DIFF
--- a/wiki/SimRel/2024-03.md
+++ b/wiki/SimRel/2024-03.md
@@ -1,0 +1,29 @@
+This documents related to 2024-03, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of March 2024.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+
+
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md)  Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2024-03 M1** | Friday, January 12, 2024 | 01/05 to 01/12 | <li>Opt-in deadline (new projects only)<li>Create your release record (for new releases) | 4 weeks from 2023-12 GA |
+| **2024-03 M2** | Friday, February 2, 2024 | 01/26 to 02/02 | | 3 weeks from M1 |
+| **2024-03 M3** | Friday, February 23, 2024 | 02/16 to 02/23 | <li>IP Log submission deadline | 3 weeks from M2 |
+| **2024-03 RC1** | Friday, March 1, 2024 | 02/23 to 03/01 | <li>No new features and APIs after this date!<li>Release Review materials due<li>New and Noteworthy entries due | 1 week from M3 |
+| **2024-03 RC2** | Friday, March 8, 2024 | 03/01 to 03/08 | 1 week from RC1 |
+| **Quiet period** | | 03/08 to 03/12 | | No builds during "quiet period". It is assumed all code is done by the end of RC2. |
+| **2024-03 GA** | Wednesday, March 13, 2024 | | Release reviews conclude on this date | 5 days from RC2 |
+
+
+<!-- googlecalendar width="600" height="400" title="Planning Council Calendar">gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20240301%2F20240331</googlecalendar -->
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20231201%2F20240331&hl=en&mode=AGENDA) <!-- markdown-link-check-disable-line -->
+
+## Non-wiki pages related to the release
+
+[List of participating
+projects](http://www.eclipse.org/projects/releases/releases.php?release=2024-03)
+

--- a/wiki/SimRel/2024-06.md
+++ b/wiki/SimRel/2024-06.md
@@ -1,0 +1,29 @@
+This documents related to 2024-06, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of June 2024.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+
+
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md)  Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2024-06 M1** | Friday, April 12, 2024 | 04/05 to 04/12 | <li>Opt-in deadline (new projects only)<li>Create your release record (for new releases) | 3 weeks from 2024-03 GA |
+| **2024-06 M2** | Friday, May 3, 2024 | 04/26 to 05/03 | | 3 weeks from M1 |
+| **2024-06 M3** | Friday, May 24, 2024 | 05/17 to 05/24 | <li>IP Log submission deadline | 3 weeks from M2 |
+| **2024-06 RC1** | Friday, May 31, 2024 | 05/24 to 05/31 | <li>No new features and APIs after this date!<li>Release Review materials due<li>New and Noteworthy entries due | 1 week from M3 |
+| **2024-06 RC2** | Friday, June 7, 2024 | 05/31 to 06/07 | 1 week from RC1 |
+| **Quiet period** | | 06/07 to 06/11 | | No builds during "quiet period". It is assumed all code is done by the end of RC2. |
+| **2024-06 GA** | Wednesday, June 12, 2024 | | Release reviews conclude on this date | 5 days from RC2 |
+
+
+<!-- googlecalendar width="600" height="400" title="Planning Council Calendar">gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20240601%2F20240630</googlecalendar -->
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20240301%2F20240630&hl=en&mode=AGENDA) <!-- markdown-link-check-disable-line -->
+
+## Non-wiki pages related to the release
+
+[List of participating
+projects](http://www.eclipse.org/projects/releases/releases.php?release=2024-06)
+

--- a/wiki/Simultaneous_Release.md
+++ b/wiki/Simultaneous_Release.md
@@ -17,14 +17,55 @@ existing simultaneous releases from the current and previous years.
 </tr>
 </thead>
 <tbody>
+
+<tr class="odd">
+<td><p>2024-06 (Future release)</p></td>
+<td><p>4.32</p></td>
+<td><p>June 12, 2024</p></td>
+<td><p><a
+href="SimRel/2024-06.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2024-06/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2024-06/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
+<tr class="even">
+<td><p>2024-03 (Future release)</p></td>
+<td><p>4.31</p></td>
+<td><p>March 13, 2024</p></td>
+<td><p><a
+href="SimRel/2024-03.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2024-03/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2024-03/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
 <tr class="odd">
 <td><p>2023-12 (Future release)</p></td>
 <td><p>4.30</p></td>
 <td><p>December 06, 2023</p></td>
 <td><p><a
 href="SimRel/2023-12.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2023-12/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2023-12/">p2
+Repository</a>
+-->
 </p></td>
 </tr>
+
 <tr class="even">
 <td><p><span style="color: green;">2023-09 (Current
 release)</span></p></td>
@@ -38,6 +79,7 @@ Download Page</a><br />
 <a href="https://download.eclipse.org/releases/2023-09/">p2
 Repository</a></p></td>
 </tr>
+
 <tr class="odd">
 <td><p>2023-06 (Last release)</p></td>
 <td><p>4.28</p></td>
@@ -50,6 +92,7 @@ Download Page</a><br />
 <a href="https://download.eclipse.org/releases/2023-06/">p2
 Repository</a></p></td>
 </tr>
+
 <tr class="even">
 <td><p>2023-03</p></td>
 <td><p>4.27</p></td>
@@ -62,6 +105,7 @@ Download Page</a><br />
 <a href="https://download.eclipse.org/releases/2023-03/">p2
 Repository</a></p></td>
 </tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
This is the release plan/dates for the 2024-03/-06 releases. This is also part of the migration off of wiki.eclipse.org (#5)

Once this is approved and merged, I will create the Google calendar entries and redirect https://wiki.eclipse.org/Simultaneous_Release to here (just as I did for https://wiki.eclipse.org/Planning_Council)

