### PR TITLE
Add 2023-11-01 Planning Council Meeting

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,7 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2023-11-01](Planning_Council/2023-11-01.md)
  - [2023-10-04](Planning_Council/2023-10-04.md)
  - [2023-09-06](Planning_Council/2023-09-06.md)
  - [2023-08-02](Planning_Council/2023-08-02.md)

--- a/wiki/Planning_Council/2023-11-01.md
+++ b/wiki/Planning_Council/2023-11-01.md
@@ -1,0 +1,28 @@
+### Actions from last meeting
+
+- **Action (Jonah)**: [Accessibility plan](2023-05-03.md#accessibility)
+- **Action (Jonah)**: Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
+- **Action (Jonah)** Remote / hybrid for Community Day. Jonah to check with organizers **DONE** No hybrid or recordings for community day from EF
+- **Action (Jonah)** Jonah to try and touch base with various community members at community day and discuss release schedules. **DONE**
+- **Action (Jonah)** Jonah to research [GLCanvas on Wayland](https://github.com/eclipse-platform/eclipse.platform.swt/issues/806) and turn into a dev effort
+
+### Discussions
+
+- Java 21 discussions
+  - Concerns discussed about Java 21 not being complete
+  - Can we even call our support Java 21 because it is incomplete
+  - What options are there? e.g. include Eclipse Project 4.29 again in 2023-12, delay 2023-12
+  - **Action (Jonah)** Contact Wayne for EF perspective
+
+- Renew [Dev Effort for Platform/Tycho releng](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/14). Planning council have found this useful so far.
+  - **Action (Jonah)** make dev effort entry
+
+- Discuss Eclipse Project [wiki migration](https://github.com/eclipse-platform/eclipse.platform/issues/747)
+  - There is lack of clarity about exactly what the technical work needed here is
+  - Not a "simple" migration as the outdated info on the wiki needs to be dealt with too
+  - Someone with knowledge of the project probably needed to make decisions of how different pieces of information are hosted
+  - **Action (Jonah)** make dev effort for wiki migration / doc update
+
+The following items were deferred to a future meeting as this meeting did not have the full attendance due to it being scheduled on holiday for many council members.
+  - what is the scope of the planning council (see [Planning Council section of charter](https://www.eclipse.org/org/workinggroups/eclipse-ide-charter.php))
+  - who should be the chair going forward


### PR DESCRIPTION
_This was initially created in https://github.com/jonahgraham/eclipse-simrel-.github/pull/1 - but it more properly lived here._


Agenda items:

- [ ] https://github.com/eclipse-platform/eclipse.platform/issues/747
- [ ] Verify [chromium dev effort is accurate](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/6)
- [ ] p2 backend changes causing problems in corporate networks
- [ ] what is the scope of the planning council (see [Planning Council section of charter](https://www.eclipse.org/org/workinggroups/eclipse-ide-charter.php))
- [ ] who should be the chair going forward