### PR TITLE
Feb 2024 Planning Council Meeting

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,8 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2024-02-07](Planning_Council/2024-02-07.md)
+ - 2023-01-03 there was no meeting due to Christmas/New Year holidays
  - [2023-12-06](Planning_Council/2023-12-06.md)
  - [2023-11-01](Planning_Council/2023-11-01.md)
  - [2023-10-04](Planning_Council/2023-10-04.md)

--- a/wiki/Planning_Council/2024-02-07.md
+++ b/wiki/Planning_Council/2024-02-07.md
@@ -1,0 +1,22 @@
+### Actions from last meeting
+
+- **Action (Jonah)**: [Accessibility plan](2023-05-03.md#accessibility)
+- **Action (Jonah)**: Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
+
+### Discussions
+
+- Discussed how to best use funded dev efforts going forward. The conclusion is that having a self managed person who can handle the review of PRs and all the other technical items previously captured in the [Onboarding mentor](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/19) dev effort
+- These are the other issues that have been highlighted recently, but for now are not under consideration as the focus needs to be on the above.
+  - [GLCanvas on Wayland](https://github.com/eclipse-platform/eclipse.platform.swt/issues/806)
+  - [blank screens macOS and latest Java](https://github.com/eclipse-platform/eclipse.platform.swt/issues/1012#issuecomment-1925329883)
+  - [SWT (and more?) support on aarch64 on win32](https://github.com/eclipse-platform/eclipse.platform.swt/issues/1019)
+  - [Rework PDE wizards to use p2](https://github.com/eclipse-pde/eclipse.pde/issues/862)
+  - [All items previously collected on board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208)
+- This should feed into the [in person meeting Feb 27](https://www.eclipse.org/lists/eclipse-ide-wg/msg00347.html)
+
+- [Java 21 (as runtime) and SimRel](https://www.eclipse.org/lists/eclipse.org-planning-council/msg03700.html) required a decision on "Make a decision when to update JustJ in EPPs to Java 21." and that led to the decision of "Update right after 2024-03 release and start the new stream with JustJ 21 and Java 21 content allowed."
+
+- Ed reports that the 2024-03 release is going well and was particularly pleased with how well everyone adopted to the new guava version.
+- Java 21 support in JDT may still be missing some features in 2024-03.
+
+- There is some cross-project concern about how Java 21 is ending up unintentionally in user installs. See [WWD#1380](https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/1380) and [Equinox p2#367](https://github.com/eclipse-equinox/p2/discussions/367) for details.


### PR DESCRIPTION
Below is the agenda for our next [planning council meeting (dial-in details)](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council.md) - please add other ideas to this discussion and we'll talk about that too. After the meeting this will be turned into discussions/notes and action points in the the markdown.

### Agenda

- Review Funded dev Efforts, here are recent items that have been flagged for consideration:
  - [GLCanvas on Wayland](https://github.com/eclipse-platform/eclipse.platform.swt/issues/806)
  - [blank screens macOS and latest Java](https://github.com/eclipse-platform/eclipse.platform.swt/issues/1012#issuecomment-1925329883)
  - [SWT (and more?) support on aarch64 on win32](https://github.com/eclipse-platform/eclipse.platform.swt/issues/1019)
  - [Rework PDE wizards to use p2](https://github.com/eclipse-pde/eclipse.pde/issues/862)
  - [All items previously collected on board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208)
- [Java 21 (as runtime) and SimRel](https://www.eclipse.org/lists/eclipse.org-planning-council/msg03700.html)
- [Preparation for in person meeting Feb 27](https://www.eclipse.org/lists/eclipse-ide-wg/msg00347.html)
- Status of 2024-03 (and early planning on -06)
