### PR TITLE
Fix link to Execution Environments

### DIFF
--- a/wiki/SimRel/Simultaneous_Release_Requirements.md
+++ b/wiki/SimRel/Simultaneous_Release_Requirements.md
@@ -290,7 +290,7 @@ bundle. (For some old history, see .)
 
 All plug-ins (that contain Java code) must correctly specify their
 [Bundle Required Execution Environment
-(BREE)](Execution_Environments "wikilink"). Resource-only bundles do not
+(BREE)](https://wiki.eclipse.org/Execution_Environments). Resource-only bundles do not
 need a BREE since it doesn't matter which version of Java they are used
 with.
 


### PR DESCRIPTION
This points to the old wiki, if anyone knows if this link is up to date elsewhere, or where it should go so I can move it, please let me know.

