### PR TITLE
Mar 2024 Planning Council Meeting

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,7 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2024-03-06](Planning_Council/2024-03-06.md)
  - [2024-02-07](Planning_Council/2024-02-07.md)
  - 2023-01-03 there was no meeting due to Christmas/New Year holidays
  - [2023-12-06](Planning_Council/2023-12-06.md)

--- a/wiki/Planning_Council/2024-03-06.md
+++ b/wiki/Planning_Council/2024-03-06.md
@@ -1,0 +1,25 @@
+### Actions from last meeting
+
+- **Action (Jonah)**: [Accessibility plan](2023-05-03.md#accessibility)
+- **Action (Jonah)**: Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
+
+### Discussions
+
+#### Funded dev efforts - specifically community engineer (aka onboarding mentor) - [gitlab #19](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/19)
+- A decision on this is expected from Steering Committee in the coming weeks
+
+#### New timing of meeting to accommodate Manoj (welcome for Manoj will be next meeting because he isn't available this week)
+- Maybe able to move 1 1/2 hours earlier. Doodle poll [sent out](https://www.eclipse.org/lists/eclipse.org-planning-council/msg03708.html).
+
+#### Jonah out of office 11-22 March
+- Ed has kindly agreed to do the last few steps of EPP release process.
+  See [endgame issue](https://github.com/eclipse-packaging/packages/issues/127) for details.
+
+#### Status of 2024-03 (and early planning on -06)
+- All reports are positive
+- Discussion on macOS issue with mac SDK version.
+  This is not under consideration for a respin even if it is fixed in time because the workaround is simple (uses different JDK version) and primarily only affects eclipse developers.
+  See [SWT issue #1012](https://github.com/eclipse-platform/eclipse.platform.swt/issues/1012) for details.
+- Discussion on Java 21 upgrade.
+  The EPP and SimRel decision are made already and [announced](https://www.eclipse.org/lists/cross-project-issues-dev/msg19843.html), but the discussion focussed instead on if/when Platform should change BREE to Java 21.
+  See [Issue #188](https://github.com/eclipse-platform/.github/discussions/188) for ongoing discussions.


### PR DESCRIPTION
Below is the agenda for our next [planning council meeting (dial-in details)](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council.md) - please add other ideas to this discussion and we'll talk about that too. After the meeting this will be turned into discussions/notes and action points in the markdown.

Agenda

- Funded dev efforts - specifically community engineer (aka onboarding mentor) - [gitlab #19](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/issues/19)
- Status of 2024-03 (and early planning on -06)
- New timing of meeting to accommodate Manoj (welcome for Manoj will be next meeting because he isn't available this week)
- Jonah out of office 11-22 March