### PR TITLE
Meeting notes for Planning Council 2024-08-07

### DIFF
--- a/wiki/Planning_Council/2024-08-07.md
+++ b/wiki/Planning_Council/2024-08-07.md
@@ -1,0 +1,29 @@
+# August 8 2024 Meeting Notes
+
+## Agenda
+
+- [Dev Efforts board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208) status
+- 2024-09 Status
+- Jonah resigning as chair
+
+## Actions from last meeting
+
+- **Action (Jonah)**: (Carried forward - see comments below) [Accessibility plan](2023-05-03.md#accessibility) - The SAP's ABAP Development Tools team have usability experts on staff ([see matrix chat](https://chat.eclipse.org/#/room/#eclipse-ide-general:matrix.eclipse.org/$Zbqh3dhE4SRx4OU21qBLlsfeMGDcZ20xm06-NOhdJvY)).
+- **Action (Jonah)**: (Carried forward) Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
+
+## Minutes
+
+- 2024-09 Status
+  - Going smoothly - actively investigating 3rd party library issue with logging ([orbit#40](https://github.com/eclipse-orbit/orbit-simrel/issues/40))
+- [Dev Efforts board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208) status
+  - Quick highlight on current state as shown in the board
+  - Heads-up that planning for next issues should be in place in Sept to hire next set of issue
+- Jonah resigning as chair
+  - Announcement made at meeting
+  - Search for new chair ongoing
+- SimRel requirements
+  - Remove jar signing requirement from SimRel for Eclipse own content, see [#28](https://github.com/eclipse-simrel/.github/pull/28)
+
+## Next meeting
+
+A reminder that the next meeting is scheduled for September 4th, 2024.


### PR DESCRIPTION
## Call details

[Zoom and meeting details](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council.md#call-and-meeting-schedule)

## Agenda

- [Dev Efforts board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208) status
- 2024-09 Status
- Jonah resigning as chair

## Next meeting

A reminder that the next meeting is scheduled for September 4th, 2024.
