### PR TITLE
Meeting notes for Planning Council 2024-09-04

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,8 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2024-09-04](Planning_Council/2024-09-04.md)
+ - [2024-08-07](Planning_Council/2024-08-07.md)
  - [2024-07-03](Planning_Council/2024-07-03.md)
  - [2024-06-05](Planning_Council/2024-06-05.md)
  - [2024-05-01](Planning_Council/2024-05-01.md)

--- a/wiki/Planning_Council/2024-09-04.md
+++ b/wiki/Planning_Council/2024-09-04.md
@@ -1,0 +1,21 @@
+# September 4 2024 Meeting Notes
+
+## Agenda
+
+- [Dev Efforts board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208) status
+  - We need to add new items to the list of high priority items
+- 2024-09 Status
+
+## Actions from last meeting
+
+- **Action (Jonah)**: (Carried forward - see comments below) [Accessibility plan](2023-05-03.md#accessibility) - The SAP's ABAP Development Tools team have usability experts on staff ([see matrix chat](https://chat.eclipse.org/#/room/#eclipse-ide-general:matrix.eclipse.org/$Zbqh3dhE4SRx4OU21qBLlsfeMGDcZ20xm06-NOhdJvY)).
+- **Action (Jonah)**: (Carried forward) Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
+- **Action (Jonah)**: Jonah resigning as chair
+- **Action (Jonah - DONE)**: Remove jar signing requirement from SimRel for Eclipse own content, see [#28](https://github.com/eclipse-simrel/.github/pull/28)
+
+## Minutes
+
+
+## Next meeting
+
+A reminder that the next meeting is scheduled for October 2nd, 2024.


### PR DESCRIPTION
# September 4 2024 Meeting Notes

## Agenda

- [Dev Efforts board](https://gitlab.eclipse.org/eclipse-wg/ide-wg/ide-wg-dev-funded-efforts/ide-wg-dev-funded-program-planning-council-top-issues/-/boards/1208) status
  - We need to add new items to the list of high priority items
- 2024-09 Status

## Actions from last meeting

- **Action (Jonah)**: (Carried forward - see comments below) [Accessibility plan](2023-05-03.md#accessibility) - The SAP's ABAP Development Tools team have usability experts on staff ([see matrix chat](https://chat.eclipse.org/#/room/#eclipse-ide-general:matrix.eclipse.org/$Zbqh3dhE4SRx4OU21qBLlsfeMGDcZ20xm06-NOhdJvY)).
- **Action (Jonah)**: (Carried forward) Update [SimRel participation rules](../SimRel/Simultaneous_Release_Requirements.md) must-dos and circulate for approval.
- **Action (Jonah)**: Jonah resigning as chair
- **Action (Jonah - DONE)**: Remove jar signing requirement from SimRel for Eclipse own content, see [#28](https://github.com/eclipse-simrel/.github/pull/28)

## Minutes


## Next meeting

A reminder that the next meeting is scheduled for October 2nd, 2024.
