### PR TITLE
2025-03 and 2025-06 SimRel Release Schedules

### DIFF
--- a/wiki/SimRel/2025-03.md
+++ b/wiki/SimRel/2025-03.md
@@ -1,0 +1,24 @@
+This documents related to 2025-03, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of March 2025.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md)  Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2025-03 M1** | Friday, January 10, 2025 | 01/03 to 01/10 | <ul><li>Opt-in deadline (new projects only)<li>Create your release record (for new releases)</ul> | 4 weeks from 2024-12 GA |
+| **2025-03 M2** | Friday, January 31, 2025 | 01/24 to 01/31 | | 3 weeks from M1 |
+| **2025-03 M3** | Friday, February 21, 2025 | 02/14 to 02/21 | <ul><li>IP Log submission deadline</ul> | 3 weeks from M2 |
+| **2025-03 RC1** | Friday, February 28, 2025 | 02/21 to 02/28 | <ul><li><b>No new features and APIs after this date!</b><li>Release Review materials due<li>New and Noteworthy entries due</ul> | 1 week from M3 |
+| **2025-03 RC2** | Friday, March 7, 2025 | 02/28 to 03/07 | | 1 week from RC1 |
+| **Quiet period** | | 03/07 to 03/11 | | No builds. It is assumed all code is done by end of RC2. |
+| **2025-03 GA** | Wednesday, March 12, 2025 | | <ul><li>Release reviews conclude on this date</ul> | 5 days from RC2 |
+
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20241201%2F20250331&hl=en&mode=AGENDA)
+
+## Non-wiki pages related to the release
+
+[List of participating projects](http://www.eclipse.org/projects/releases/2025-03)
+

--- a/wiki/SimRel/2025-06.md
+++ b/wiki/SimRel/2025-06.md
@@ -1,0 +1,24 @@
+This documents related to 2025-06, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of June 2025.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md)  Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2025-06 M1** | Friday, April 11, 2025 | 04/04 to 04/11 | <ul><li>Opt-in deadline (new projects only)<li>Create your release record (for new releases)</ul> | 3 weeks from 2025-03 GA |
+| **2025-06 M2** | Friday, May 2, 2025 | 04/25 to 05/02 | | 3 weeks from M1 |
+| **2025-06 M3** | Friday, May 23, 2025 | 05/16 to 05/23 | <ul><li>IP Log submission deadline</ul> | 3 weeks from M2 |
+| **2025-06 RC1** | Friday, May 30, 2025 | 05/23 to 05/30 | <ul><li><b>No new features and APIs after this date!</b><li>Release Review materials due<li>New and Noteworthy entries due</ul> | 1 week from M3 |
+| **2025-06 RC2** | Friday, June 6, 2025 | 05/30 to 06/06 | | 1 week from RC1 |
+| **Quiet period** | | 06/06 to 06/10 | | No builds. It is assumed all code is done by end of RC2. |
+| **2025-06 GA** | Wednesday, June 11, 2025 | | <ul><li>Release reviews conclude on this date</ul> | 5 days from RC2 |
+
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20241201%2F20250331&hl=en&mode=AGENDA)
+
+## Non-wiki pages related to the release
+
+[List of participating projects](http://www.eclipse.org/projects/releases/2025-06)
+

--- a/wiki/Simultaneous_Release.md
+++ b/wiki/Simultaneous_Release.md
@@ -19,6 +19,38 @@ existing simultaneous releases from the current and previous years.
 <tbody>
 
 <tr class="odd">
+<td><p>2025-06 (Future release)</p></td>
+<td><p>4.36</p></td>
+<td><p>June 11, 2024</p></td>
+<td><p><a
+href="SimRel/2025-06.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2025-06/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2025-06/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
+<tr class="even">
+<td><p>2025-03 (Future release)</p></td>
+<td><p>4.35</p></td>
+<td><p>March 12, 2025</p></td>
+<td><p><a
+href="SimRel/2025-03.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2025-03/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2025-03/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
+<tr class="odd">
 <td><p>2024-12 (Future release)</p></td>
 <td><p>4.34</p></td>
 <td><p>December 04, 2024</p></td>


### PR DESCRIPTION
This adds SimRel release schedules for the 2025-03 and 2025-06 releases. They are adapted from the schedules for the 2024-03 and 2024-06 releases. The planning council agreed on not deriving from these schedules (https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council/2024-11-06.md).

Once this is approved and merged, I will create the according Google calendar entries.