### PR TITLE
Meeting notes for Planning Council 2025-03-05

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,7 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2025-03-05](Planning_Council/2025-03-05.md)
  - [2025-02-05](Planning_Council/2025-02-05.md)
  - [2025-01-08](Planning_Council/2025-01-08.md)
  - [2024-12-04](Planning_Council/2024-12-04.md)

--- a/wiki/Planning_Council/2025-03-05.md
+++ b/wiki/Planning_Council/2025-03-05.md
@@ -1,0 +1,44 @@
+# 2025-03-05 Meeting Notes
+
+## Agenda
+
+- Status 2025-03
+- Change in release policy (Java version support) for 2025-09 release (JDK 24)? (Follow-up from 2024-11 meeting)
+- Badges proposals: https://gitlab.eclipse.org/eclipse-wg/ide-wg/community/-/issues/71
+
+
+## Minutes
+
+### Status 2025-03
+- No issues reported
+  - Ed installed and tested everything from current Staging
+  - glibc dependency issue (high version constraint) has been resolved
+- JDT support for Java 24 is in good shape
+  - Ed compiled platform with JDT patch for Java 24
+  - New way of informing about Java release will show up directly after Java 24 release: https://github.com/eclipse-oomph/oomph/issues/134#issuecomment-2697560675
+
+### Java Support Schedule
+- Background: discussion on changes regarding schedule alignment between Eclipse SimRel and Java version support in JDT discussed in November
+  - Agreed on not making Eclipse Release depend on Java version support in JDT
+  - Discussed whether available Java support in Eclipse release for Java 25 can be improved (Java constants and runtime support)
+- Java 24 development is already separated into multiple steps
+  - In particular, constants and runtime will be integrated rather early
+  - Still they are only present in beta branch and not in master to be published with 2025-03
+- To improve support of new Java version in Eclipse release, constants and runtime detection would have to happen in JDT master
+  - Then, without ECJ support for Java language features, Java 25 would be properly recognized
+  - This was done for Java 22, but JDT Debug had issues with it --> also work in JDT Debug and JDT UI required
+  - Alex wanted to work on this, but will probably not be able to do so
+- Proposal: document the task regarding Java 25 and make it more public/visible to maybe have someone else pick the task
+
+### Recognition Badges
+- https://gitlab.eclipse.org/eclipse-wg/ide-wg/community/-/issues/71
+- "Frequent Committer"
+  - Bad metrics as an issue can take long to resolve
+  - In general: badges should give a good/reasonable incentive (so maybe "Bug Fixer" also gives a bad incentive, as it would, e.g., favor many irrelevant fixes or fewer relevant ones)
+- Proposal: "Bug Reporter" as an additional badge
+- Maybe think about expiration dates or repeated badges limited to specific time periods (like "Best Committer 2025")
+
+
+## Next Meeting
+
+Next meeting will be on April 2nd, 2025.


### PR DESCRIPTION
### Discussed Topics
- Status 2025-03
- Change in release policy (Java version support) for 2025-09 release (JDK 25)? (Follow-up from [2024-11 meeting](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council/2024-11-06.md))
- Badges proposals: https://gitlab.eclipse.org/eclipse-wg/ide-wg/community/-/issues/71

### Formatted Document Preview
https://github.com/HeikoKlare/eclipse-simrel-.github/blob/planning-council-2025-03-05/wiki/Planning_Council/2025-03-05.md