### PR TITLE
Meeting notes for Planning Council 2025-04-02

### DIFF
--- a/wiki/Planning_Council.md
+++ b/wiki/Planning_Council.md
@@ -59,6 +59,7 @@ Telephone Dial in (for higher quality, dial a number based on your curr
 
 ### Meeting notes
 
+ - [2025-04-02](Planning_Council/2025-04-02.md)
  - [2025-03-05](Planning_Council/2025-03-05.md)
  - [2025-02-05](Planning_Council/2025-02-05.md)
  - [2025-01-08](Planning_Council/2025-01-08.md)

--- a/wiki/Planning_Council/2025-04-02.md
+++ b/wiki/Planning_Council/2025-04-02.md
@@ -1,0 +1,32 @@
+# 2025-04-02 Meeting Notes
+
+## Agenda
+
+- Schedules 2025-09 and 2025-12
+  - Proposal: take dates from last year, except 2025-12 one week earlier (as agree on in [meeting 2024-11](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council/2024-11-06.md))
+  - Heiko will create schedule with exact dates afterwards
+
+
+## Minutes
+
+- Release date proposals:
+  - 2025-09-10
+  - 2025-12-10
+- SWT: WebKit problem
+  - Webkit installation on swt github runners had to be downgraded by explicitly installing older versions via `apt-get install package=<version>`: https://github.com/eclipse-platform/eclipse.platform.swt/pull/1980
+  - When will the old versions disappear from ubuntu repos?
+- JDT: Bad autocomplete performance
+  - Noticeable on huge workspace used by Vector
+  - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2125
+- Idea by Ed: Use the new view technology that hints to new Java version support also to
+  - propose installing milestones
+    - concern: Wording needs to be right so people know what to expect
+      - encounter bugs
+      - chance to report bugs and get them fixed earlier
+    - Ed will try it out
+  - donations/sponsorships
+
+
+## Next Meeting
+
+Next meeting will be on May 7th, 2025.


### PR DESCRIPTION
- Schedules for 2025-09 and 2025-12 releases
  - Proposal: take dates from last year, except 2025-12 one week earlier (as agree on in [meeting 2024-11](https://github.com/eclipse-simrel/.github/blob/main/wiki/Planning_Council/2024-11-06.md))
  - Heiko will create schedule with exact dates afterwards

_Note:_ As announced in last meeting, I will not be able to attend this meeting. Would be nice if someone can take over the moderation and take some notes. Thank you!