### PR TITLE
2025-09 and 2025-12 SimRel Release Schedules

### DIFF
--- a/wiki/SimRel/2025-09.md
+++ b/wiki/SimRel/2025-09.md
@@ -1,0 +1,24 @@
+This documents related to 2025-09, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of September 2025.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md) Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2025-09 M1** | Friday, July 11, 2025 | 07/04 to 07/11 | <ul><li>Opt-in deadline (new projects only)<li>Create your release record (for new releases)</ul> | 4 weeks from 2025-06 GA |
+| **2025-09 M2** | Friday, August 1, 2025 | 07/25 to 08/01 | | 3 weeks from M1 |
+| **2025-09 M3** | Friday, August 22, 2025 | 08/15 to 08/22 | <ul><li>IP Log submission deadline</ul> | 3 weeks from M2 |
+| **2025-09 RC1** | Friday, August 29, 2025 | 08/22 to 08/29 | <ul><li><b>No new features and APIs after this date!</b><li>Release Review materials due<li>New and Noteworthy entries due</ul> | 1 week from M3 |
+| **2025-09 RC2** | Friday, September 5, 2025 | 08/29 to 09/05 | | 1 week from RC1 |
+| **Quiet period** | | 09/05 to 09/09 | | No builds. It is assumed all code is done by end of RC2. |
+| **2025-09 GA** | Wednesday, September 10, 2025 | | <ul><li>Release reviews conclude on this date</ul> | 5 days from RC2 |
+
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20250601%2F20250930&hl=en&mode=AGENDA)
+
+## Non-wiki pages related to the release
+
+[List of participating projects](http://www.eclipse.org/projects/releases/2025-09)
+

--- a/wiki/SimRel/2025-12.md
+++ b/wiki/SimRel/2025-12.md
@@ -1,0 +1,24 @@
+This documents related to 2025-12, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of December 2025.
+
+## Common information
+
+- [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
+- [Simultaneous Release Plan](Simultaneous_Release_Plan.md) Information that stays the same for each release, like requirements for participation, communication channels, etc.
+
+## Release schedule
+| **Release** | **Date** | **Span** | **Due dates** | **Notes** |
+|---|---|---|---|---|
+| **2025-12 M1** | Friday, October 10, 2025 | 10/03 to 10/10 | <ul><li>Opt-in deadline (new projects only)<li>Create your release record (for new releases)</ul> | 4 weeks from 2025-09 GA |
+| **2025-12 M2** | Friday, October 31, 2025 | 10/24 to 10/31 | | 3 weeks from M1 |
+| **2025-12 M3** | Friday, November 21, 2025 | 11/14 to 11/21 | <ul><li>IP Log submission deadline</ul> | 3 weeks from M2 |
+| **2025-12 RC1** | Friday, November 28, 2025 | 11/21 to 11/28 | <ul><li><b>No new features and APIs after this date!</b><li>Release Review materials due<li>New and Noteworthy entries due</ul> | 1 week from M3 |
+| **2025-12 RC2** | Friday, December 5, 2025 | 11/28 to 12/05 | | 1 week from RC1 |
+| **Quiet period** | | 12/05 to 12/09 | | No builds. It is assumed all code is done by end of RC2. |
+| **2025-12 GA** | Wednesday, December 10, 2025 | | <ul><li>Release reviews conclude on this date</ul> | 5 days from RC2 |
+
+[Google Calendar Link](https://calendar.google.com/calendar/embed?src=gchs7nm4nvpm837469ddj9tjlk@group.calendar.google.com&dates=20250901%2F20251231&hl=en&mode=AGENDA)
+
+## Non-wiki pages related to the release
+
+[List of participating projects](http://www.eclipse.org/projects/releases/2025-12)
+

--- a/wiki/Simultaneous_Release.md
+++ b/wiki/Simultaneous_Release.md
@@ -19,6 +19,38 @@ existing simultaneous releases from the current and previous years.
 <tbody>
 
 <tr class="odd">
+<td><p>2025-12 (Future release)</p></td>
+<td><p>4.38</p></td>
+<td><p>December 10, 2025</p></td>
+<td><p><a
+href="SimRel/2025-12.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2025-12/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2025-12/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
+<tr class="even">
+<td><p>2025-09 (Future release)</p></td>
+<td><p>4.37</p></td>
+<td><p>September 10, 2025</p></td>
+<td><p><a
+href="SimRel/2025-09.md">Wiki</a><br />
+<!-- Uncomment on release day
+<a
+href="https://www.eclipse.org/downloads/packages/release/2025-09/r">Package
+Download Page</a><br />
+<a href="https://download.eclipse.org/releases/2025-09/">p2
+Repository</a>
+-->
+</p></td>
+</tr>
+
+<tr class="odd">
 <td><p>2025-06 (Future release)</p></td>
 <td><p>4.36</p></td>
 <td><p>June 11, 2025</p></td>
@@ -35,7 +67,7 @@ Repository</a>
 </tr>
 
 <tr class="even">
-<td><p>2025-03  (Current release)</p></td>
+<td><p>2025-03 (Current release)</p></td>
 <td><p>4.35</p></td>
 <td><p>March 12, 2025</p></td>
 <td><p><a


### PR DESCRIPTION
This adds SimRel release schedules for the 2025-09 and 2025-12 releases. They are adapted from the schedules for the 2024-09 and 2024-12 releases with the exception that the dates for the December release have been shifted to one week later (as a correction for every year the release being one day earlier). The planning council agreed on these schedules in the meeting on 2025-04-02 (https://github.com/eclipse-simrel/.github/pull/42).

Once this is approved and merged, I will create the according Google calendar entries.

The rendered pages can, for example, be seen via these links:
- [Schedule 2025-09](https://github.com/HeikoKlare/eclipse-simrel-.github/blob/simrel-schedules-2025-09_12/wiki/SimRel/2025-09.md)
- [Schedule 2025-12](https://github.com/HeikoKlare/eclipse-simrel-.github/blob/simrel-schedules-2025-09_12/wiki/SimRel/2025-12.md)