### PR TITLE
Document impact of infrastructure issues on 2025-06

### DIFF
--- a/wiki/SimRel/2025-06.md
+++ b/wiki/SimRel/2025-06.md
@@ -1,16 +1,20 @@
 This documents related to 2025-06, the Eclipse Foundation's multi-project [Simultaneous Release](../Simultaneous_Release.md) of June 2025.
 
+## Delayed M2
+**Note:** Due to ongoing issues with the Eclipse Foundation infrastructure affecting or even preventing builds for projects contributing to SimRel (particularly including Eclipse Platform), we have delayed M2 by one week. The subsequent dates for M3 and RCs stay the same. We continuously monitor the status of Eclipse Foundation infrastructure and reevaluate further impact on the release schedule.
+
 ## Common information
 
 - [Simultaneous Release Requirements](Simultaneous_Release_Requirements.md)  (aka must-dos)
 - [Simultaneous Release Plan](Simultaneous_Release_Plan.md)  Information that stays the same for each release, like requirements for participation, communication channels, etc.
 
 ## Release schedule
+
 | **Release** | **Date** | **Span** | **Due dates** | **Notes** |
 |---|---|---|---|---|
 | **2025-06 M1** | Friday, April 11, 2025 | 04/04 to 04/11 | <ul><li>Opt-in deadline (new projects only)<li>Create your release record (for new releases)</ul> | 3 weeks from 2025-03 GA |
-| **2025-06 M2** | Friday, May 2, 2025 | 04/25 to 05/02 | | 3 weeks from M1 |
-| **2025-06 M3** | Friday, May 23, 2025 | 05/16 to 05/23 | <ul><li>IP Log submission deadline</ul> | 3 weeks from M2 |
+| **2025-06 M2** | Friday, May 9 <s>2</s>, 2025 | 04/25 to 05/09 <s>05/02</s> | | <s>3</s> 4 weeks from M1 (delayed by one week due to infrastructure issues) |
+| **2025-06 M3** | Friday, May 23, 2025 | 05/16 to 05/23 | <ul><li>IP Log submission deadline</ul> | <s>3</s> 2 weeks from M2 |
 | **2025-06 RC1** | Friday, May 30, 2025 | 05/23 to 05/30 | <ul><li><b>No new features and APIs after this date!</b><li>Release Review materials due<li>New and Noteworthy entries due</ul> | 1 week from M3 |
 | **2025-06 RC2** | Friday, June 6, 2025 | 05/30 to 06/06 | | 1 week from RC1 |
 | **Quiet period** | | 06/06 to 06/10 | | No builds. It is assumed all code is done by end of RC2. |


### PR DESCRIPTION
Current infrastructure issues affect the 2025-06 release process, in particular the current M2. This documents the current situation at the according Wiki page for the 2025-06 SimRel and proposes a delay of one week for M2.