### PR TITLE
Improve the documentation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -19,6 +19,7 @@ The [SimRel Wiki](../wiki/README.md) provides details about the processes involv
 - [SimRel Overview](../wiki/SimRel/Overview.md)
 - [SimRel Requirements](../wiki/SimRel/Simultaneous_Release_Requirements.md)
 - [SimRel Roles](../wiki/SimRel/Simultaneous_Release_Roles.md)
+- [SimRel Plan](../wiki/SimRel/Simultaneous_Release_Plan.md)
 - [SimRel Contribution](../wiki/SimRel/Contributing_to_Simrel_Aggregation_Build.md)
 - [SimRel FAQ](../wiki/SimRel/Simultaneous_Release_Cycle_FAQ.md)
 - [SimRel Checklist](../wiki/SimRel/Release_Checklist.md)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-# Eclipse IDE Simultaneous Release (SimRel)
+# SimRel Wiki
 
 A number of Eclipse projects harmonize their development activities to produce releases on a coordinated schedule 
 to produce the so-called *simultaneous release*, *coordinated release*, or *release train* of Eclipse.
@@ -25,6 +25,7 @@ This folder also provides provides details about the processes involved in produ
 - [SimRel Overview](SimRel/Overview.md)
 - [SimRel Requirements](SimRel/Simultaneous_Release_Requirements.md)
 - [SimRel Roles](SimRel/Simultaneous_Release_Roles.md)
+- [SimRel Plan](SimRel/Simultaneous_Release_Plan.md)
 - [SimRel Contribution](SimRel/Contributing_to_Simrel_Aggregation_Build.md)
 - [SimRel FAQ](SimRel/Simultaneous_Release_Cycle_FAQ.md)
 - [SimRel Checklist](SimRel/Release_Checklist.md)

--- a/wiki/SimRel/Simultaneous_Release_Plan.md
+++ b/wiki/SimRel/Simultaneous_Release_Plan.md
@@ -1,3 +1,5 @@
+# SimRel Plan
+
 This document contains the boiler-plate information for every [Simultaneous Release](../Simultaneous_Release.md) after Photon.
 
 ### Requirements For Participation

--- a/wiki/SimRel/Simultaneous_Release_Requirements.md
+++ b/wiki/SimRel/Simultaneous_Release_Requirements.md
@@ -1,4 +1,4 @@
-# The Eclipse Simultaneous Release Requirements
+# SimRel Requirements
 
 Updated April 28, 2025
 

--- a/wiki/SimRel/Simultaneous_Release_Roles.md
+++ b/wiki/SimRel/Simultaneous_Release_Roles.md
@@ -1,4 +1,4 @@
-## Simultaneous Release Roles
+## SimRel Roles
 
 Many tasks and activities must take place to produce our [Simultaneous Release](../Simultaneous_Release.md),
 and the [Planning Council](../Planning_Council.md) is responsible for many of those tasks and activities.

--- a/wiki/Simultaneous_Release.md
+++ b/wiki/Simultaneous_Release.md
@@ -1,4 +1,4 @@
-# Eclipse IDE Simultaneous Release (SimRel)
+# Eclipse IDE SimRel Schedule
 
 The [Eclipse Foundation](https://wiki.eclipse.org/Foundation) and its community of
 projects and contributors produce releases on a coordinated schedule


### PR DESCRIPTION
- Make the first header more consistent across the documents.
- Include a link to the plan.