### PR TITLE
Fix formatting of quiet period rows in SimRel schedules

### DIFF
--- a/wiki/SimRel/2019-09.md
+++ b/wiki/SimRel/2019-09.md
@@ -72,11 +72,11 @@ September 2019.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/13 to 09/17</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2019-09 GA</p></td>

--- a/wiki/SimRel/2019-12.md
+++ b/wiki/SimRel/2019-12.md
@@ -75,11 +75,11 @@ December 2019.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>12/13 to 12/17</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2019-12 GA</p></td>

--- a/wiki/SimRel/2020-03.md
+++ b/wiki/SimRel/2020-03.md
@@ -75,11 +75,11 @@ March 2020.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>03/13 to 03/17</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2020-03 GA</p></td>

--- a/wiki/SimRel/2020-06.md
+++ b/wiki/SimRel/2020-06.md
@@ -75,11 +75,11 @@ June 2020.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>06/12 to 06/16</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2020-06 GA</p></td>

--- a/wiki/SimRel/2020-09.md
+++ b/wiki/SimRel/2020-09.md
@@ -75,11 +75,11 @@ September 2020.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/11 to 09/15</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2020-09 GA</p></td>

--- a/wiki/SimRel/2020-12.md
+++ b/wiki/SimRel/2020-12.md
@@ -75,11 +75,11 @@ December 2020.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>12/11 to 12/15</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2020-12 GA</p></td>

--- a/wiki/SimRel/2021-03.md
+++ b/wiki/SimRel/2021-03.md
@@ -75,11 +75,11 @@ March 2021.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>03/12 to 03/16</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2021-03 GA</p></td>

--- a/wiki/SimRel/2021-06.md
+++ b/wiki/SimRel/2021-06.md
@@ -75,11 +75,11 @@ June 2021.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>06/11 to 06/15</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2021-06 GA</p></td>

--- a/wiki/SimRel/2021-09.md
+++ b/wiki/SimRel/2021-09.md
@@ -75,11 +75,11 @@ September 2021.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/10 to 09/14</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2021-09 GA</p></td>

--- a/wiki/SimRel/2021-12.md
+++ b/wiki/SimRel/2021-12.md
@@ -75,11 +75,11 @@ December 2021.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>12/03 to 12/07</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2021-12 GA</p></td>

--- a/wiki/SimRel/2022-03.md
+++ b/wiki/SimRel/2022-03.md
@@ -75,11 +75,11 @@ March 2022.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>03/11 to 03/15</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2022-03 GA</p></td>

--- a/wiki/SimRel/2022-06.md
+++ b/wiki/SimRel/2022-06.md
@@ -78,11 +78,11 @@ June 2022.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>06/10 to 06/14</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2022-06 GA</p></td>

--- a/wiki/SimRel/2022-09.md
+++ b/wiki/SimRel/2022-09.md
@@ -74,11 +74,11 @@ September 2022.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/09 to 09/13</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2022-09 GA</p></td>

--- a/wiki/SimRel/2022-12.md
+++ b/wiki/SimRel/2022-12.md
@@ -74,11 +74,11 @@ December 2022.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>12/02 to 12/06</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2022-12 GA</p></td>

--- a/wiki/SimRel/2023-03.md
+++ b/wiki/SimRel/2023-03.md
@@ -74,11 +74,11 @@ March 2023.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>03/10 to 03/14</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2023-03 GA</p></td>

--- a/wiki/SimRel/2023-06.md
+++ b/wiki/SimRel/2023-06.md
@@ -77,11 +77,11 @@ June 2023.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>06/09 to 06/13</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2023-06 GA</p></td>

--- a/wiki/SimRel/2023-09.md
+++ b/wiki/SimRel/2023-09.md
@@ -74,11 +74,11 @@ September 2023.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/08 to 09/12</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2023-09 GA</p></td>

--- a/wiki/SimRel/2023-12.md
+++ b/wiki/SimRel/2023-12.md
@@ -74,11 +74,11 @@ December 2023.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>12/01 to 12/05</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2023-12 GA</p></td>

--- a/wiki/SimRel/2024-09.md
+++ b/wiki/SimRel/2024-09.md
@@ -74,11 +74,11 @@ September 2024.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>09/06 to 09/10</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2024-09 GA</p></td>

--- a/wiki/SimRel/2024-12.md
+++ b/wiki/SimRel/2024-12.md
@@ -74,11 +74,11 @@ December 2024.
 </tr>
 <tr class="even">
 <td><p>Quiet period</p></td>
+<td></td>
 <td><p>11/29 to 12/03</p></td>
 <td></td>
 <td><p>No builds during "quiet period". It is assumed all code is done
 by the end of RC2.</p></td>
-<td></td>
 </tr>
 <tr class="odd">
 <td><p>2024-12 GA</p></td>


### PR DESCRIPTION
It's correct in the entries for 2025-03 and later but older entires are wrongly formatted.

## Example

### Before
<img width="1030" height="611" alt="image" src="https://github.com/user-attachments/assets/76fdd4dd-759d-41a4-a788-f477cb37a167" />

### After
<img width="1031" height="738" alt="image" src="https://github.com/user-attachments/assets/c60d7daf-5e38-45a7-a8fb-4d9e67e2e335" />
